### PR TITLE
Update build process and plugin version

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -24,4 +24,4 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle
-        run: ./gradlew build
+        run: ./gradlew buildPlugin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle
-        run: ./gradlew clean build
+        run: ./gradlew clean buildPlugin
       - name: Release
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 0.2.0-beta2
+- Aiken Language Support
+- Yaci DevKit Integration
 ### 0.1.5
 
 - Support for Cardano-graphql

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
 plugins {
     id 'java'
     id 'idea'
-    id 'org.jetbrains.intellij.platform' version '2.0.1'
+    id 'org.jetbrains.intellij.platform' version '2.1.0'
     id "org.jetbrains.kotlin.jvm" version "1.9.25"
     id "org.jetbrains.grammarkit" version "2022.3.2.2"
 }
@@ -107,4 +107,6 @@ grammarKit {
 
 patchPluginXml {
     changeNotes = changeLogAsHtml()
+    sinceBuild = "242"
+    untilBuild = provider {null}
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -10,8 +10,6 @@
     <p><a href="https://intelliada.bloxbean.com">Documentation</a>
     ]]></description>
 
-    <idea-version since-build="242"/>
-
     <!-- please see https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html
          on how to target different products -->
     <depends>com.intellij.modules.platform</depends>


### PR DESCRIPTION
Updated the build command from `build` to `buildPlugin` in workflow files and upgraded the Gradle IntelliJ plugin to version 2.1.0. Added `sinceBuild` and `untilBuild` in `patchPluginXml` within `build.gradle` for better version control, and documented the new features in the CHANGELOG.