### PR TITLE
Add AikenConfigurationAction to CardanoExplorer UI

### DIFF
--- a/src/main/java/com/bloxbean/intelliada/idea/aiken/compile/AikenCompileService.java
+++ b/src/main/java/com/bloxbean/intelliada/idea/aiken/compile/AikenCompileService.java
@@ -57,7 +57,7 @@ public class AikenCompileService extends BaseCompileService {
 
             @Override
             public void processTerminated(@NotNull ProcessEvent event) {
-                if(event.getExitCode() == 0) {
+                if(event.getExitCode() == 0 || (SystemInfo.isWindows && event.getExitCode() <= 0)) { //Workaround as exit code for successful build on Windows is returned as a negative value
                     listener.info("Compilation successful.");
                     listener.onSuccessful(sourceFilePath);
                 } else {

--- a/src/main/java/com/bloxbean/intelliada/idea/aiken/configuration/AikenConfigurationAction.java
+++ b/src/main/java/com/bloxbean/intelliada/idea/aiken/configuration/AikenConfigurationAction.java
@@ -1,9 +1,9 @@
 package com.bloxbean.intelliada.idea.aiken.configuration;
 
+import com.bloxbean.intelliada.idea.aiken.common.AikenIcons;
 import com.bloxbean.intelliada.idea.aiken.configuration.service.AikenProjectState;
 import com.bloxbean.intelliada.idea.aiken.configuration.ui.AikenProjectConfigurationDialog;
 import com.bloxbean.intelliada.idea.util.IdeaUtil;
-import com.intellij.icons.AllIcons;
 import com.intellij.notification.NotificationType;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
@@ -14,7 +14,7 @@ public class AikenConfigurationAction extends AnAction {
     public static final String ACTION_ID = AikenConfigurationAction.class.getName();
 
     public AikenConfigurationAction() {
-        super(AllIcons.Ide.Notification.Gear);
+        super(AikenIcons.AIKEN_ICON);
     }
 
     @Override

--- a/src/main/java/com/bloxbean/intelliada/idea/toolwindow/ui/CardanoExplorer.java
+++ b/src/main/java/com/bloxbean/intelliada/idea/toolwindow/ui/CardanoExplorer.java
@@ -1,6 +1,7 @@
 package com.bloxbean.intelliada.idea.toolwindow.ui;
 
 import com.bloxbean.intelliada.idea.account.action.AccountListAction;
+import com.bloxbean.intelliada.idea.aiken.configuration.AikenConfigurationAction;
 import com.bloxbean.intelliada.idea.configuration.action.*;
 import com.bloxbean.intelliada.idea.configuration.model.CLIProvider;
 import com.bloxbean.intelliada.idea.configuration.model.RemoteNode;
@@ -189,6 +190,8 @@ public class CardanoExplorer extends SimpleToolWindowPanel implements DataProvid
         scriptGroup.add(new ListScriptsAction());
 
         group.add(scriptGroup);
+        group.add(new Separator());
+        group.add(new AikenConfigurationAction());
 
         final ActionToolbar actionToolBar = ActionManager.getInstance().createActionToolbar(ActionPlaces.ANT_EXPLORER_TOOLBAR, group, true);
         actionToolBar.setTargetComponent(this);


### PR DESCRIPTION
Integrate AikenConfigurationAction into the CardanoExplorer toolbar for better configuration management. 
Also, apply a workaround for Windows build process exit codes in AikenCompileService and update the icon for AikenConfigurationAction to use AikenIcons.